### PR TITLE
make prophecies public

### DIFF
--- a/TestDoubleBundle.php
+++ b/TestDoubleBundle.php
@@ -28,8 +28,8 @@ final class TestDoubleBundle extends Bundle implements CompilerPassInterface
                     $container->setAlias($id, $config['fake']);
                 }
                 else {
-                    $container->setDefinition("$id.prophecy", (new Definition)->setSynthetic(true));
-                    $container->setDefinition("$id.stub", (new Definition)->setSynthetic(true));
+                    $container->setDefinition("$id.prophecy", (new Definition)->setSynthetic(true)->setPublic(true));
+                    $container->setDefinition("$id.stub", (new Definition)->setSynthetic(true)->setPublic(true));
 
                     $container->setAlias($id, "$id.stub");
 


### PR DESCRIPTION
in symfony 4, services will be private by default.

i found this bundle while looking how to replace the http://github.com/polishsymfonycommunity/symfony-mocker-container package when moving to symfony 4. but it looks like this bundle does not really support symfony 4 either. does it make sense to update it, or should i look at something else?