### PR TITLE
Make stub.prophet public by default?

### DIFF
--- a/TestDoubleBundle.php
+++ b/TestDoubleBundle.php
@@ -41,7 +41,7 @@ final class TestDoubleBundle extends Bundle implements CompilerPassInterface
                 }
             }
         }
-        $container->setDefinition('stub.prophet', (new Definition)->setSynthetic(true));
+        $container->setDefinition('stub.prophet', (new Definition)->setSynthetic(true)->setPrivate(false));
         $container->setParameter('stub.services', $ids);
     }
 


### PR DESCRIPTION
In SF4 you can have services as private by default, it then throws this exception:
```
The "stub.prophet" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0
```

So by making it public it will be compatible with SF4